### PR TITLE
react-docgen-imported-proptype-handler@1.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -279,14 +279,12 @@
       }
     },
     "react-docgen-imported-proptype-handler": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/react-docgen-imported-proptype-handler/-/react-docgen-imported-proptype-handler-1.0.1.tgz",
-      "integrity": "sha512-xDhxjNuDqs3rS/FgBQyr5aZrMnGuZDUnO6ZZEvhIBpYJ36i+M0Ls7Bt7sWdx3/s+Qhjw+ShAptSmMXGfoJZYOA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/react-docgen-imported-proptype-handler/-/react-docgen-imported-proptype-handler-1.0.3.tgz",
+      "integrity": "sha512-oVNJat49B3skm3W5zCVk1CxOJBUGPgNd3rMK79egUuv8TemANhZJVZ421zIk6iMp2BV3pb2dkXiihBZnzqwlOQ==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.2.0",
-        "react-docgen": "2.21.0",
-        "recast": "^0.12.9"
+        "@babel/runtime": "^7.2.0"
       }
     },
     "react-router": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "devDependencies": {
     "glob": "^7.1.3",
     "react-docgen": "^2.21.0",
-    "react-docgen-imported-proptype-handler": "^1.0.1"
+    "react-docgen-imported-proptype-handler": "^1.0.3",
+    "recast": "^0.12.9"
   },
   "scripts": {
     "docgen": "node scripts/docgen.js",


### PR DESCRIPTION
- bump `react-docgen-imported-proptype-handler` to latest `1.0.3`
- installs proper `recast@0.12.9` peerDependency as devDependency
